### PR TITLE
[fix][security] Replace protocol-relative URLs with https:// to resolve CORS issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,8 +78,8 @@
     <body>
         <nav class="navbar navbar-default">
             <div class="flex-container-main">
-                <a class="logo" href="//bar.utoronto.ca" target="_blank">
-                    <img src="//bar.utoronto.ca/BAR/images/BAR.png">
+                <a class="logo" href="https://bar.utoronto.ca" target="_blank">
+                    <img src="https://bar.utoronto.ca/BAR/images/BAR.png">
                 </a>
 
                 <div class="flex-container-title">

--- a/scripts/aiv.js
+++ b/scripts/aiv.js
@@ -1206,7 +1206,7 @@
         else if ( (regexGroup = referenceStr.match(/doi:(.*)/i)) ){
             if (regexGroup[0] === "doi:10.1016/j.cell.2016.04.038"){
                 console.log(regexGroup, AGIIdentifier, TF);
-                return `<a href="//bar.utoronto.ca/DAP-Seq-API?target=${AGIIdentifier}&tf=${TF}" target="_blank"> DAP-Seq (O'Malley 2016)</a>`
+                return `<a href="https://bar.utoronto.ca/DAP-Seq-API?target=${AGIIdentifier}&tf=${TF}" target="_blank"> DAP-Seq (O'Malley 2016)</a>`
             }
             return `<a href="http://dx.doi.org/${regexGroup[1]}" target="_blank"> ${db} DOI ${regexGroup[1]} </a>`;
         }
@@ -1841,7 +1841,7 @@
      * @returns {string} - url for the HTTP request
      */
     AIV.createGETMapManURL = function () {
-        let mapmanURL = "//bar.utoronto.ca/interactions2/cgi-bin/bar_mapman.php?request=[";
+        let mapmanURL = "https://bar.utoronto.ca/interactions2/cgi-bin/bar_mapman.php?request=[";
         this.parseProteinNodes((nodeID) => mapmanURL +=`"${nodeID}",`);
         mapmanURL = mapmanURL.slice(0,-1); //remove last ','
         mapmanURL += "]";
@@ -2258,7 +2258,7 @@
      */
     AIV.createGeneSummariesAjaxPromise = function(ABIs) {
         return $.ajax({
-            url: "//bar.utoronto.ca/interactions2/cgi-bin/gene_summaries_POST.php",
+            url: "https://bar.utoronto.ca/interactions2/cgi-bin/gene_summaries_POST.php",
             type: "POST",
             data: JSON.stringify(ABIs),
             contentType: "application/json",

--- a/scripts/aiv_ui.js
+++ b/scripts/aiv_ui.js
@@ -295,7 +295,7 @@
      */
     function getXMLSourcesModifyDropdown(){
         $.ajax({
-            url: "//bar.utoronto.ca/interactions2/cgi-bin/getXML.php?species=arabidopsis",
+            url: "https://bar.utoronto.ca/interactions2/cgi-bin/getXML.php?species=arabidopsis",
             type: "GET"
         })
             .then((res)=>{
@@ -320,7 +320,7 @@
                 return;
             }
             $.ajax({
-               url: "//bar.utoronto.ca/interactions2/cgi-bin/getTissues.php?species=arabidopsis&dataSource=" + event.target.value,
+               url: "https://bar.utoronto.ca/interactions2/cgi-bin/getTissues.php?species=arabidopsis&dataSource=" + event.target.value,
                type: "GET",
             })
                 .then((res) =>{
@@ -472,7 +472,7 @@
 
     function createExpressionAJAX(listOfAGIsAndExprsnModes, mode, AIVObj) {
         return $.ajax({
-            url: "//bar.utoronto.ca/interactions2/cgi-bin/getSample.php",
+            url: "https://bar.utoronto.ca/interactions2/cgi-bin/getSample.php",
             type: "POST",
             data: JSON.stringify( listOfAGIsAndExprsnModes ),
             contentType : 'application/json',
@@ -634,7 +634,7 @@
      */
     function checkBIOGRIDServerStatus(){
         $.ajax({
-            url: "//bar.utoronto.ca/interactions2/cgi-bin/psicquic_biogrid_proxy.php?request=AT1G01010",
+            url: "https://bar.utoronto.ca/interactions2/cgi-bin/psicquic_biogrid_proxy.php?request=AT1G01010",
             type: "GET"
         })
             .then((res, text, xhr)=>{
@@ -655,7 +655,7 @@
      */
     function checkINTACTServerStatus(){
         $.ajax({
-            url: "//bar.utoronto.ca/interactions2/cgi-bin/psicquic_intact_proxy.php?request=AT1G01010",
+            url: "https://bar.utoronto.ca/interactions2/cgi-bin/psicquic_intact_proxy.php?request=AT1G01010",
             type: "GET"
         })
             .then((res, text, xhr)=>{
@@ -676,7 +676,7 @@
      */
     function effectorDropdownSelect2() {
         $.ajax({
-            url: "//bar.utoronto.ca/interactions2/cgi-bin/get_effectors.php",
+            url: "https://bar.utoronto.ca/interactions2/cgi-bin/get_effectors.php",
             type: "GET"
         })
             .then((res)=>{


### PR DESCRIPTION
Description:

This PR addresses a CORS issue where `about://` URLs were being generated in iframes, leading to blocked requests due to strict CORS policies. The solution involves replacing protocol-relative URLs (`//`) with `https://` to ensure that requests are made over a secure protocol, avoiding `about://` issues.